### PR TITLE
Fix for Restore Ruins Prestige + Tradeport Requirement

### DIFF
--- a/common/scripted_guis/zz_agot_ruins_override.txt
+++ b/common/scripted_guis/zz_agot_ruins_override.txt
@@ -59,6 +59,7 @@
 						is_coastal_county = yes
 					}
 				}
+				trigger_else = { always = no }
 			}
 		}
 		trigger_if = {


### PR DESCRIPTION
Fix to coastal ruins being restorable even without prestige level 4 + tradeport level 6