### PR TITLE
Religion and Adjacency Patch for AGOT 0.4.1

### DIFF
--- a/common/religion/religions/00_agot_the_flames.txt
+++ b/common/religion/religions/00_agot_the_flames.txt
@@ -243,7 +243,7 @@
 			doctrine = doctrine_polygamy
 			doctrine = doctrine_divorce_approval
 			doctrine = doctrine_bastardry_legitimization
-			doctrine = doctrine_consanguinity_unrestricted
+			doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece
 
 			#Criminology Doctrines
 			doctrine = doctrine_homosexuality_shunned
@@ -294,7 +294,7 @@
 			doctrine = doctrine_polygamy
 			doctrine = doctrine_divorce_allowed
 			doctrine = doctrine_bastardry_legitimization
-			doctrine = doctrine_consanguinity_unrestricted
+			doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece
 
 			#Criminology Doctrines
 			doctrine = doctrine_homosexuality_shunned
@@ -523,7 +523,7 @@
 			doctrine = doctrine_concubines
 			doctrine = doctrine_divorce_approval
 			doctrine = doctrine_bastardry_legitimization
-			doctrine = doctrine_consanguinity_unrestricted
+			doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece
 
 			#Criminology Doctrines
 			doctrine = doctrine_homosexuality_crime

--- a/map_data/adjacencies.csv
+++ b/map_data/adjacencies.csv
@@ -73,6 +73,7 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;Comment
 1647;1649;sea;6180;-1;-1;-1;-1;Salmon Stream - Iron Tooth (4.24)
 1755;1763;sea;6208;-1;-1;-1;-1;Hiddenhall - Eaglewood (6.71)
 1919;7265;sea;6370;-1;-1;-1;-1;Tallpine Keep - Misty Isle (2.0)
+2063;1728;sea;6528;-1;-1;-1;-1;Wolf's Bend - Lord's Mill (2.0)
 2298;2300;sea;6369;-1;-1;-1;-1;Strand Valley - Deepstone (5.0)
 2299;2300;sea;6369;-1;-1;-1;-1;Reece - Deepstone (3.0)
 2301;2306;sea;6368;-1;-1;-1;-1;Mullbry Keep - Wakerock (5.0)


### PR DESCRIPTION
- Changed consanguinity doctrine of Valyrian faiths from unrestricted to aunt/nephew and uncle/niece
- Added strait/sea crossing between Wolf's Bend and Lord's Mill